### PR TITLE
Don't quote file name argument to `call-process`

### DIFF
--- a/bug-hunter.el
+++ b/bug-hunter.el
@@ -229,8 +229,7 @@ the file."
           (with-temp-file file-name
             (print (list 'prin1 form) (current-buffer)))
           (call-process exec nil out-buf nil
-                        "-Q" "--batch" "-l"
-                        (shell-quote-argument file-name))
+                        "-Q" "--batch" "-l" file-name)
           (with-current-buffer out-buf
             (goto-char (point-max))
             (forward-sexp -1)


### PR DESCRIPTION
I'm not sure why you did that, but `shell-quote-argument` for `call-process` looks very wrong.  With `call-process` there's no shell involved…
