### PR TITLE
Repair tests for emacs 28+

### DIFF
--- a/bug-hunter-test.el
+++ b/bug-hunter-test.el
@@ -69,14 +69,14 @@
       (insert "(setq useless 1)\n#\n(setq useless 1)\n"))
     (should
      (equal (bug-hunter-file file nil)
-            [(invalid-read-syntax "#") 2 0]))
+            [(invalid-read-syntax "#" 2 1) 2 0]))
     (should
-     (equal '(bug-caught (invalid-read-syntax "#") 2 0)
+     (equal '(bug-caught (invalid-read-syntax "#" 2 1) 2 0)
             (bug-hunter--read-contents file)))
     (with-temp-file file
       (insert "(setq useless 1)\n)\n(setq useless 1)\n"))
     (should
-     (equal '(bug-caught (invalid-read-syntax ")") 2 0)
+     (equal '(bug-caught (invalid-read-syntax ")" 2 1) 2 0)
             (bug-hunter--read-contents file)))
     (with-temp-file file
       (insert "(setq useless 1)\n(\n(setq useless 1)\n"))

--- a/bug-hunter-test.el
+++ b/bug-hunter-test.el
@@ -69,9 +69,9 @@
       (insert "(setq useless 1)\n#\n(setq useless 1)\n"))
     (should
      (equal (bug-hunter-file file nil)
-            [(invalid-read-syntax "#" 2 1) 2 0]))
+            [(invalid-read-syntax "#" 3 0) 2 0]))
     (should
-     (equal '(bug-caught (invalid-read-syntax "#" 2 1) 2 0)
+     (equal '(bug-caught (invalid-read-syntax "#" 3 0) 2 0)
             (bug-hunter--read-contents file)))
     (with-temp-file file
       (insert "(setq useless 1)\n)\n(setq useless 1)\n"))


### PR DESCRIPTION
Since emacs 28, the byte-compiler is a little bit more specific in its error reporting.

When it encounters an error of the `invalid-read-syntax` kind, it provides not only the offending character (this it did before), but also the line and column of this character.

The tests must be modified to reflect that change.

Best,

Aymeric Agon-Rambosson

Closes #33