### PR TITLE
Prevent byte-compiler warning in code and docstrings

### DIFF
--- a/README.org
+++ b/README.org
@@ -88,3 +88,18 @@ but the point is the same. But fear not! There’s a simple solution:
 
 1. If you have any code above the call to ~org-babel-tangle-file~, copy that to the top of ~org-init.el~ (or whatever is the name of your tangled file). This includes that ~(require 'org)~ over there.
 2. Invoke ~M-x~ ~bug-hunter-file~ (instead of ~bug-hunter-init-file~). It will ask you which file to debug, and you need to point it to your tangled output file ~org-init.el~.
+   
+* Specifying additional code
+
+If you need to specify additional code to be run before or after the
+code that you are bisecting, set ~bug-hunter-header~ or
+~bug-hunter-footer~ to a single s-expression. Use ~progn~ to combine
+multiple expressions if needed. For example:
+
+#+begin_src emacs-lisp :eval no
+(setq bug-hunter-header
+			'(progn
+				 (package-initialize)
+				 (use-package quelpa)
+				 (use-package quelpa-use-package)))
+#+end_src

--- a/bug-hunter-test.el
+++ b/bug-hunter-test.el
@@ -84,6 +84,21 @@
      (equal '(bug-caught (end-of-file) 2 0)
             (bug-hunter--read-contents file)))))
 
+(ert-deftest bug-hunter-test-header ()
+	(let* ((bug-hunter-header '(setq another-variable 1))
+				 (temp (bug-hunter--print-to-temp '(setq useless 1))))
+		(with-temp-buffer
+			(insert-file-contents temp)
+			(delete-file temp)
+			(should (re-search-forward "another-variable" nil t)))))
+
+(ert-deftest bug-hunter-test-footer ()
+	(let* ((bug-hunter-footer '(setq another-variable 1))
+				 (temp (bug-hunter--print-to-temp '(setq useless 1))))
+		(with-temp-buffer
+			(insert-file-contents temp)
+			(delete-file temp)
+			(should (re-search-forward "another-variable" nil t)))))
 
 (provide 'bug-hunter-test)
 ;;; bug-hunter-test.el ends here

--- a/bug-hunter-test.el
+++ b/bug-hunter-test.el
@@ -69,14 +69,14 @@
       (insert "(setq useless 1)\n#\n(setq useless 1)\n"))
     (should
      (equal (bug-hunter-file file nil)
-            [(invalid-read-syntax "#") 2 0]))
+            [(invalid-read-syntax "#" 2 1) 2 0]))
     (should
-     (equal '(bug-caught (invalid-read-syntax "#") 2 0)
+     (equal '(bug-caught (invalid-read-syntax "#" 2 1) 2 0)
             (bug-hunter--read-contents file)))
     (with-temp-file file
       (insert "(setq useless 1)\n)\n(setq useless 1)\n"))
     (should
-     (equal '(bug-caught (invalid-read-syntax ")") 2 0)
+     (equal '(bug-caught (invalid-read-syntax ")" 2 1) 2 0)
             (bug-hunter--read-contents file)))
     (with-temp-file file
       (insert "(setq useless 1)\n(\n(setq useless 1)\n"))

--- a/bug-hunter-test.el
+++ b/bug-hunter-test.el
@@ -69,9 +69,9 @@
       (insert "(setq useless 1)\n#\n(setq useless 1)\n"))
     (should
      (equal (bug-hunter-file file nil)
-            [(invalid-read-syntax "#" 2 1) 2 0]))
+            [(invalid-read-syntax "#" 3 0) 2 0]))
     (should
-     (equal '(bug-caught (invalid-read-syntax "#" 2 1) 2 0)
+     (equal '(bug-caught (invalid-read-syntax "#" 3 0) 2 0)
             (bug-hunter--read-contents file)))
     (with-temp-file file
       (insert "(setq useless 1)\n)\n(setq useless 1)\n"))

--- a/bug-hunter-test.el
+++ b/bug-hunter-test.el
@@ -1,3 +1,5 @@
+;;; bug-hunter-test.el --- ert test for bug-hunter.  -*- lexical-binding: t; -*-
+
 (unless (bound-and-true-p package--initialized)
   (setq
    package-user-dir (expand-file-name
@@ -7,7 +9,7 @@
   (package-initialize))
 
 (require 'ert)
-(require 'cl)
+(require 'cl-lib)
 (require 'bug-hunter)
 ;; (fset 'bug-hunter--report #'ignore)
 ;; (fset 'bug-hunter--report-end #'ignore)
@@ -69,9 +71,9 @@
       (insert "(setq useless 1)\n#\n(setq useless 1)\n"))
     (should
      (equal (bug-hunter-file file nil)
-            [(invalid-read-syntax "#" 3 0) 2 0]))
+            [(invalid-read-syntax "#\n" 3 0) 2 0]))
     (should
-     (equal '(bug-caught (invalid-read-syntax "#" 3 0) 2 0)
+     (equal '(bug-caught (invalid-read-syntax "#\n" 3 0) 2 0)
             (bug-hunter--read-contents file)))
     (with-temp-file file
       (insert "(setq useless 1)\n)\n(setq useless 1)\n"))

--- a/bug-hunter.el
+++ b/bug-hunter.el
@@ -258,13 +258,18 @@ the file."
 
 
 ;;; Execution functions
+(defvar bug-hunter-header nil "Emacs Lisp sexp to add at the beginning of the file.")
+(defvar bug-hunter-footer nil "Emacs Lisp sexp to add at the end of the file.")
+
 (defun bug-hunter--print-to-temp (sexp)
   "Print SEXP to a temp file and return the file name."
   (let ((print-length nil)
         (print-level nil)
         (file (make-temp-file "bug-hunter")))
     (with-temp-file file
-      (print sexp (current-buffer)))
+      (when bug-hunter-header (print bug-hunter-header (current-buffer)))
+      (print sexp (current-buffer))
+      (when bug-hunter-footer (print bug-hunter-footer (current-buffer))))
     file))
 
 (defun bug-hunter--run-emacs (file &rest args)

--- a/bug-hunter.el
+++ b/bug-hunter.el
@@ -310,7 +310,7 @@ ARGS are passed before \"-l FILE\"."
   "Execute FORMS in the background and test ASSERTION.
 See `bug-hunter' for a description on the ASSERTION.
 
-If ASSERTION is 'interactive, the form is run through
+If ASSERTION is \\='interactive, the form is run through
 `bug-hunter--run-form-interactively'.  Otherwise, a slightly
 modified version of the form combined with ASSERTION is run
 through `bug-hunter--run-form'."
@@ -462,13 +462,16 @@ To use automatic error detection, type e
 To provide a lisp assertion, type a
 => ")
 
+(eval-when-compile
+  (defvar minibuffer-completing-symbol))   ; prevent by-compilation warning
+
 (defun bug-hunter--read-from-minibuffer ()
   "Read a list of expressions from the minibuffer.
 Wraps them in a progn if necessary to always return a single
 form.
 
 The user may decide to not provide input, in which case
-'interactive is returned.  Note, this is different from the user
+\\='interactive is returned.  Note, this is different from the user
 typing `RET' at an empty prompt, in which case nil is returned."
   (pcase (read-char-choice (if (display-graphic-p)
                                bug-hunter--hunt-type-prompt


### PR DESCRIPTION
Hi,  I integrated ever other PR in my fork, fixed the byte compiler warnings I see wiht Emacs 30 and fixed the ert test as of Emacs 30.